### PR TITLE
Indexing bugfix in InvadedCluster

### DIFF
--- a/ateams/models/InvadedCluster.py
+++ b/ateams/models/InvadedCluster.py
@@ -206,11 +206,13 @@ class InvadedCluster():
 				_births, _deaths = zip(*pairs)
 				births = set(_births)
 				deaths = set(_deaths)
-
-				return set(
+				_essential = sorted(set(
 					e for e in times-(births|deaths)
 					if low <= e < high
-				)
+				))
+
+				return np.array([_essential[self._STOP]], dtype=int)
+			
 			
 			def persist(filtration):
 				essential = ComputePersistencePairs(self.matrices.full, filtration, self.dimension, self.complex.breaks)

--- a/ateams/models/InvadedCluster.py
+++ b/ateams/models/InvadedCluster.py
@@ -211,7 +211,8 @@ class InvadedCluster():
 					if low <= e < high
 				))
 
-				return np.array([_essential[self._STOP]], dtype=int)
+				if self.full: return np.array(_essential, dtype=int)
+				else: return np.array([_essential[self._STOP]], dtype=int)
 			
 			
 			def persist(filtration):


### PR DESCRIPTION
Small bug pointed out by @spanini2 and @malakoutimichael: for $q=2$, `InvadedCluster.persist()` method would return a Python `set` object when reporting homological percolation times. Now returns an `np.array` with in-order homological percolation times.